### PR TITLE
Migrate to Nextclade3 [#1]

### DIFF
--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -172,7 +172,7 @@ rule mask:
         """
 
 
-rule nextalign_after_mask:
+rule align_after_mask:
     input:
         fasta="builds/{build}/masked.fasta",
         reference="config/reference.fasta",
@@ -180,14 +180,14 @@ rule nextalign_after_mask:
     output:
         alignment="builds/{build}/aligned.fasta",
     params:
-        template_string=lambda w: f"builds/{w.build}/translations/gene.{{gene}}.fasta",
+        template_string=lambda w: f"builds/{w.build}/translations/gene.{{cds}}.fasta",
         genes=",".join(genes),
     shell:
         """
-        nextalign run \
+        nextclade run \
             --input-ref {input.reference} \
-            --input-gene-map {input.genemap} \
-            --genes {params.genes} \
+            --input-annotation {input.genemap} \
+            --cds-selection {params.genes} \
             --output-translations {params.template_string} \
             --output-fasta {output.alignment} \
             -- {input.fasta}

--- a/phylogenetic/Snakefile
+++ b/phylogenetic/Snakefile
@@ -46,7 +46,7 @@ rule prealign:
         tsv="pre-processed/nextclade.tsv",
     shell:
         """
-        ./bin/nextclade run \
+        nextclade run \
             --input-ref {input.reference} \
             --input-annotation {input.genemap} \
             --output-tsv pre-processed/nextclade.tsv \


### PR DESCRIPTION
## Description of proposed changes

Changes `nextalign` call to `nextclade`, along with minor changes to argument names.

Also changes an unrelated `./bin/nextclade` to just `nextclade`. 

Note that the phylo build completes with no new errors after this change, but there are a number of metadata warnings emitted during the build. Those appear to be unchanged by this change. 

## Related issue(s)

Closes #1 

<!--
Link any related issues here. Use GitHub's special keywords if appropriate¹.
Type `#` followed the name of an issue and GitHub will auto-suggest the issue number for you.

¹ https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
-->

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
