### PR TITLE
Parse genotype from entrez

### DIFF
--- a/ingest/Snakefile
+++ b/ingest/Snakefile
@@ -10,6 +10,8 @@ rule all:
 
 include: "rules/fetch_from_ncbi.smk"
 include: "rules/curate.smk"
+include: "rules/entrez.smk"
+
 
 rule clean:
     params:

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -3,6 +3,8 @@
 # taxon for `rubella`
 ncbi_taxon_id: "11041"
 
+entrez_term: "\"Rubella virus\"[porgn:__txid11041]"
+
 # The list of NCBI Datasets fields to include from NCBI Datasets output
 # These need to be the "mnemonics" of the NCBI Datasets fields, see docs for full list of fields
 # https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/command-line/dataformat/tsv/dataformat_tsv_virus-genome/#fields
@@ -129,3 +131,4 @@ curate:
     - authors
     - institution
     - url
+    - genotype_metadata

--- a/ingest/rules/entrez.smk
+++ b/ingest/rules/entrez.smk
@@ -1,0 +1,30 @@
+
+
+rule fetch_entrez:
+    params:
+        term=config["entrez_term"]
+    output:
+        gb="data/entrez.gb"
+    # Allow retries in case of network errors
+    retries: 3
+    log:
+        "logs/fetch_entrez.txt",
+    benchmark:
+        "benchmarks/fetch_entrez.txt"
+    shell:
+        r"""
+        vendored/fetch-from-ncbi-entrez --term {params.term:q} --output {output.gb} > {log:q} 2>&1
+        """
+
+rule genbank_to_json:
+    # This needs the `bio` CLI <https://www.bioinfo.help/> as well as jq
+    input:
+        gb = rules.fetch_entrez.output.gb
+    output:
+        ndjson = "data/entrez.ndjson"
+    shell:
+        r"""
+        bio json {input.gb} \
+            | jq -c '.[]' \
+            > {output.ndjson}
+        """

--- a/ingest/rules/entrez.smk
+++ b/ingest/rules/entrez.smk
@@ -25,6 +25,6 @@ rule genbank_to_json:
     shell:
         r"""
         bio json {input.gb} \
-            | jq -c '.[]' \
+            | jq -c '.[] | {{accession: .record.accessions[0], entrez: .}}' \
             > {output.ndjson}
         """

--- a/ingest/scripts/extract-genotype
+++ b/ingest/scripts/extract-genotype
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
 """
-Parse ENTREZ records in NDJSON format and extracts the genotype
+Expects the NDJSON records (on STDIN) to have the GenBank data under the 'entrez'
+key. Write out the records on STDOUT with an additional 'genotype_metadata' key.
 """
 
 from augur.io.json import load_ndjson
-import argparse
+import json
 from collections.abc import Generator
 from collections import defaultdict
 import re
 from pprint import pp
-from sys import stderr
-from csv import DictWriter
+from sys import stderr, stdin, stdout
 
 def clean_up_genotype(genotype: str) -> str|None:
     if genotype.startswith("RV"):
@@ -72,38 +72,18 @@ def potential_fields(record: dict) -> Generator[str, None, None]:
     yield source_feature(record).get("title", "")
 
 
-def accession(record: dict) -> str:
-    return record['record']['accessions'][0]
-
-
 if __name__=="__main__":
-    parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument('--ndjson', required=True, type=str)
-    parser.add_argument('--output', required=True, type=str, help='Output file (TSV)')
-    args = parser.parse_args()
-
-    with open(args.ndjson) as fh:
-        records = [r for r in load_ndjson(fh)]
-
     counts = {'records': 0, 'match': 0, 'observed_genotypes': defaultdict(int)}
-    output = []
-
-    for record in records:
+    for record in load_ndjson(stdin):
+        genbank = record['entrez']
+        accession = record['accession']
         counts["records"]+=1
-        try:
-            for field in potential_fields(record):
-                if genotype:=extract_genotype(field):
-                    counts['match']+=1
-                    counts['observed_genotypes'][genotype]+=1
-                    output.append({'accession': accession(record), 'genotype_metadata': genotype})
-                    raise StopIteration
-        except StopIteration:
-            pass
-
+        genotype = ""
+        for field in potential_fields(genbank):
+            if genotype:=extract_genotype(field):
+                counts['match']+=1
+                counts['observed_genotypes'][genotype]+=1
+                break
+        record['genotype_metadata'] = genotype
+        print(json.dumps(record), end="\n", file=stdout)
     pp(counts, stream=stderr)
-
-    with open(args.output, 'w', newline='') as fh:
-        tsv_writer = DictWriter(fh, list(output[0].keys()), delimiter='\t')
-        tsv_writer.writeheader()
-        for row in output:
-            tsv_writer.writerow(row)

--- a/ingest/scripts/extract-genotype
+++ b/ingest/scripts/extract-genotype
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""
+Parse ENTREZ records in NDJSON format and extracts the genotype
+"""
+
+from augur.io.json import load_ndjson
+import argparse
+from collections.abc import Generator
+from collections import defaultdict
+import re
+from pprint import pp
+from sys import stderr
+from csv import DictWriter
+
+def clean_up_genotype(genotype: str) -> str|None:
+    if genotype.startswith("RV"):
+        genotype = genotype[2:]
+    if genotype.endswith(';'):
+        genotype = genotype[:-1]
+
+    # coerce to uppercase -- NOTE: John A mentioned there is semantic meaning
+    # in case here. TODO XXX
+    genotype = genotype.upper()
+
+    # Some strain names encode "CRS" in what we interpret to be the genotype...
+    if genotype=='CRS':
+        return None
+    if genotype=='UNKNOWN' or genotype=='GENOTYPE':
+        return None
+
+    return genotype
+
+
+def extract_genotype(s: str) -> str|None:
+    # genotype is often explicitly noted
+    if groups:=re.search("[Gg]enotype:? (\S+)", s):
+        return clean_up_genotype(groups[1])
+    # look for genotype encoded in strain name. Strain names examples:
+    # RVs/Osaka.JPN/33.12[1E]
+    # RVs/Shizuoka.JPN/13.15/[1E]
+    # RVs/Osaka.JPN/39.13/[2B](CRS)
+    # RVi/Tokyo.JPN18.13[2B]
+    # RVi/Taipei.TWN/08.09/2
+    if groups:=re.search("(\S+/\S+(/\S+){0,2})", s):
+        strain_name = groups[1]
+        if g:=re.search(".*\[(\S+)\]", strain_name):
+            return clean_up_genotype(g[1])
+
+    return None
+
+
+def source_feature(record: dict):
+    return next((f for f in record['features'] if f['type']=='source'), {})
+
+
+def as_list(x: str|list[str]) -> list[str]:
+    return x if isinstance(x, list) else [x]
+
+
+def potential_fields(record: dict) -> Generator[str, None, None]:
+    """
+    Yields strings which may contain genotype information
+    """
+    yield from as_list(record['record'].get('isolate', []))
+    yield from as_list(record['record'].get('note', []))
+    yield from as_list(record['record'].get('organism', []))
+    yield from as_list(record['record'].get('strain', []))
+    # Not considering source_feature(record).get("annotations", "").get("isolate", "")
+    # as (it seems) it's the same as record.isolate
+    yield record['record'].get('source', "")
+    yield source_feature(record).get("strain", "")
+    yield source_feature(record).get("title", "")
+
+
+def accession(record: dict) -> str:
+    return record['record']['accessions'][0]
+
+
+if __name__=="__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--ndjson', required=True, type=str)
+    parser.add_argument('--output', required=True, type=str, help='Output file (TSV)')
+    args = parser.parse_args()
+
+    with open(args.ndjson) as fh:
+        records = [r for r in load_ndjson(fh)]
+
+    counts = {'records': 0, 'match': 0, 'observed_genotypes': defaultdict(int)}
+    output = []
+
+    for record in records:
+        counts["records"]+=1
+        try:
+            for field in potential_fields(record):
+                if genotype:=extract_genotype(field):
+                    counts['match']+=1
+                    counts['observed_genotypes'][genotype]+=1
+                    output.append({'accession': accession(record), 'genotype_metadata': genotype})
+                    raise StopIteration
+        except StopIteration:
+            pass
+
+    pp(counts, stream=stderr)
+
+    with open(args.output, 'w', newline='') as fh:
+        tsv_writer = DictWriter(fh, list(output[0].keys()), delimiter='\t')
+        tsv_writer.writeheader()
+        for row in output:
+            tsv_writer.writerow(row)

--- a/phylogenetic/defaults/auspice_config.json
+++ b/phylogenetic/defaults/auspice_config.json
@@ -24,6 +24,11 @@
       "key": "country",
       "title": "Country",
       "type": "categorical"
+    },
+    {
+      "key": "genotype_metadata",
+      "title": "Genotype (GenBank annotation)",
+      "type": "categorical"
     }
   ],
   "geo_resolutions": ["region", "country"],


### PR DESCRIPTION
Downloads ENTREZ records, converts them to NDJSON and uses a custom script to parse the genotype from the underlying GenBank record. The download takes under 2min for c. 4k records. We were able to parse genotypes from 3653/4181 records (87%), and we may be able to extract genotypes from some of the remaining records if we spend more time inspecting them.

Simple additions here are to parse the epiweek from the strain name and use this as the sample date (range) when sample date is not known.

This commit is a WIP due to a few questions in the script and the usage of the bio CLI to convert GenBank to NDJSON. We should also use consistent colours for clades & genotypes.


## Comparing GenBank-annotated genotypes vs current `augur clade` designations:

I'm implicitly assuming the GenBank annotations are "correct", but this is not necessarily the case!

### Genome tree
* Broad agreement
* The samples which didn't get assigned a clade are not shown here (n=24)
* Similarly 5 samples don't have GenBank genotypes
* The single `clade=1a(VAX)-L1` is [OM735669](https://www.ncbi.nlm.nih.gov/nuccore/OM735669) which is annotated as clade 2B

<img width="960" alt="image" src="https://github.com/user-attachments/assets/27952eb6-8a92-4b96-9efe-4489dfdf959f" />

---

### E1 tree
* Almost all samples have a GenBank genotype - maybe 5 are missing one. My hunch is that the ~500 samples which our parsing didn't identify a genotype are sequences which don't cover the E1 gene and thus aren't able to be genotyped.
* Quite a few currently missing a clade annotation
* Clade 1H looks like it includes 1G samples
* All clade 1a(VAX)-L1 samples are actually labelled as "1E" in GenBank
* A single [1B sample](https://www.ncbi.nlm.nih.gov/nuccore/OM735623) is called as clade 1D
* A single [1E sample](https://www.ncbi.nlm.nih.gov/nuccore/MT359101) is called as clade 2B
* Conversely a single [2B sample](https://www.ncbi.nlm.nih.gov/nuccore/KU601217) is called as clade 1E

<img width="960" alt="image" src="https://github.com/user-attachments/assets/9af6fd09-b89c-4ad8-adaa-3361d5b75147" />



## Updated Ingest DAG

See <https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1745366262183639> for a discussion about the general approach of downloading ENTREZ and converting to NDJSON. We may wish to take this further and switch the curate pipeline to use ENTREZ-derived data, or we may wish to use ENTREZ data for certain fields only (such as strain name, genotype etc).

<img width="930" alt="image" src="https://github.com/user-attachments/assets/251cec0a-84c4-494e-a0a6-6cf77c087931" />


