### PR TITLE
Add GenBank download and parse to ingest

### DIFF
--- a/ingest/build-configs/ci/copy_example_data.smk
+++ b/ingest/build-configs/ci/copy_example_data.smk
@@ -11,18 +11,3 @@ rule copy_example_ncbi_data:
 
 # force this rule over NCBI data fetch
 ruleorder: copy_example_ncbi_data > fetch_ncbi_dataset_package
-
-
-rule copy_example_geolocation_rules:
-    input:
-        general_geolocation_rules="example-data/general-geolocation-rules.tsv",
-    output:
-        general_geolocation_rules="data/general-geolocation-rules.tsv",
-    shell:
-        r"""
-        cp -f {input.general_geolocation_rules} {output.general_geolocation_rules}
-        """
-
-
-# force this rule over downloading geolocation rules
-ruleorder: copy_example_geolocation_rules > fetch_general_geolocation_rules

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -3,6 +3,9 @@
 # taxon for `rubella`
 ncbi_taxon_id: "11041"
 
+# entrez search term for `rubella`
+entrez_search_term: "txid11041[Primary Organism]"
+
 # The list of NCBI Datasets fields to include from NCBI Datasets output
 # These need to be the "mnemonics" of the NCBI Datasets fields, see docs for full list of fields
 # https://www.ncbi.nlm.nih.gov/datasets/docs/v2/reference-docs/command-line/dataformat/tsv/dataformat_tsv_virus-genome/#fields

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -35,7 +35,7 @@ curate:
   field_map:
     accession: accession
     accession_version: accession_version
-    isolate-lineage: strain
+    isolate-lineage: isolate_lineage
     geo-region: region
     geo-location: location
     release-date: date_released
@@ -102,6 +102,7 @@ curate:
     - accession
     - accession_version
     - strain
+    - isolate_lineage
     - genbank_genotype
     - region
     - country

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -25,10 +25,6 @@ ncbi_datasets_fields:
 
 # Config parameters related to the curate pipeline
 curate:
-  # URL pointed to public generalized geolocation rules.
-  # For the Nextstrain team, this is currently
-  # "https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv".
-  geolocation_rules_url: "https://raw.githubusercontent.com/nextstrain/ncov-ingest/master/source-data/gisaid_geoLocationRules.tsv"
   # The path to the local geolocation rules within the pathogen repo
   local_geolocation_rules: "defaults/geolocation_rules.tsv"
   # List of field names to change where the key is the original field

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -105,15 +105,17 @@ curate:
     - accession
     - accession_version
     - strain
-    - date
     - region
     - country
     - division
     - location
-    - length
+    - date
     - date_released
     - date_updated
+    - length
     - full_authors
     - authors
     - institution
+    - is_lab_host
+    - is_vaccine_strain
     - url

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -51,11 +51,6 @@ curate:
     submitter-affiliation: institution
     is-lab-host: is_lab_host
     is-vaccine-strain: is_vaccine_strain
-  # Standardized strain name regex
-  # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
-  strain_regex: "^.+$"
-  # Back up strain name field to use if "strain" doesn"t match regex above
-  strain_backup_fields: ["accession"]
   # List of date fields to standardize to ISO format YYYY-MM-DD
   date_fields: ["date", "date_released", "date_updated"]
   # Field name storing `geo_loc_name` value

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -12,8 +12,6 @@ entrez_search_term: "txid11041[Primary Organism]"
 # Note: the "accession" field MUST be provided to match with the sequences
 ncbi_datasets_fields:
   - accession
-  - sourcedb
-  - sra-accs
   - isolate-lineage
   - geo-region
   - geo-location
@@ -21,12 +19,10 @@ ncbi_datasets_fields:
   - release-date
   - update-date
   - length
-  - host-name
-  - isolate-lineage-source
-  - biosample-acc
   - submitter-names
   - submitter-affiliation
-  - submitter-country
+  - is-lab-host
+  - is-vaccine-strain
 
 # Config parameters related to the curate pipeline
 curate:
@@ -44,8 +40,6 @@ curate:
   field_map:
     accession: accession
     accession_version: accession_version
-    sourcedb: database
-    sra-accs: sra_accessions
     isolate-lineage: strain
     geo-region: region
     geo-location: location
@@ -53,12 +47,10 @@ curate:
     release-date: date_released
     update-date: date_updated
     length: length
-    host-name: host
-    isolate-lineage-source: sample_type
-    biosample-acc: biosample_accessions
     submitter-names: full_authors
     submitter-affiliation: institution
-    submitter-country: submitter_country
+    is-lab-host: is_lab_host
+    is-vaccine-strain: is_vaccine_strain
   # Standardized strain name regex
   # Currently accepts any characters because we do not have a clear standard for strain names across pathogens
   strain_regex: "^.+$"
@@ -124,10 +116,8 @@ curate:
     - division
     - location
     - length
-    - host
     - date_released
     - date_updated
-    - sra_accessions
     - full_authors
     - authors
     - institution

--- a/ingest/defaults/config.yaml
+++ b/ingest/defaults/config.yaml
@@ -15,7 +15,6 @@ ncbi_datasets_fields:
   - isolate-lineage
   - geo-region
   - geo-location
-  - isolate-collection-date
   - release-date
   - update-date
   - length
@@ -43,7 +42,6 @@ curate:
     isolate-lineage: strain
     geo-region: region
     geo-location: location
-    isolate-collection-date: date
     release-date: date_released
     update-date: date_updated
     length: length
@@ -59,7 +57,8 @@ curate:
   # provided above. These date formats should use directives expected
   # by datetime.
   # See https://docs.python.org/3.9/library/datetime.html#strftime-and-strptime-format-codes
-  expected_date_formats: ["%Y", "%Y-%m", "%Y-%m-%d", "%Y-%m-%dT%H:%M:%SZ"]
+  expected_date_formats:
+    ["%Y", "%Y-%m", "%Y-%m-%d", "%d-%b-%Y", "%b-%Y", "%Y-%m-%dT%H:%M:%SZ"]
   titlecase:
     # List of string fields to titlecase
     fields: ["region", "country", "division", "location"]
@@ -100,11 +99,14 @@ curate:
   output_id_field: "accession"
   # The field in the NDJSON record that contains the actual genomic sequence
   output_sequence_field: "sequence"
+  # The column name to use to join main metadata with GenBank genotype data
+  metadata_id_column: "accession"
   # The list of metadata columns to keep in the final output of the curation pipeline.
   metadata_columns:
     - accession
     - accession_version
     - strain
+    - genbank_genotype
     - region
     - country
     - division

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -67,8 +67,6 @@ rule curate:
         "benchmarks/curate.txt"
     params:
         field_map=format_field_map(config["curate"]["field_map"]),
-        strain_regex=config["curate"]["strain_regex"],
-        strain_backup_fields=config["curate"]["strain_backup_fields"],
         date_fields=config["curate"]["date_fields"],
         expected_date_formats=config["curate"]["expected_date_formats"],
         genbank_location_field=config["curate"]["genbank_location_field"],
@@ -87,9 +85,6 @@ rule curate:
             | augur curate rename \
                 --field-map {params.field_map} \
             | augur curate normalize-strings \
-            | augur curate transform-strain-name \
-                --strain-regex {params.strain_regex:q} \
-                --backup-fields {params.strain_backup_fields:q} \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \
                 --expected-date-formats {params.expected_date_formats:q} \

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -13,11 +13,14 @@ OUTPUTS:
 """
 
 
-def format_field_map(field_map: dict[str, str]) -> str:
+def format_field_map(field_map: dict[str, str]) -> list[str]:
     """
-    Format dict to `"key1"="value1" "key2"="value2"...` for use in shell commands.
+    Format entries to the format expected by `augur curate --field-map`.
+
+    When used in a Snakemake shell block, the list is automatically expanded and
+    spaces are handled by quoted interpolation.
     """
-    return " ".join([f'"{key}"="{value}"' for key, value in field_map.items()])
+    return [f"{key}={value}" for key, value in field_map.items()]
 
 
 rule curate:
@@ -50,7 +53,7 @@ rule curate:
         r"""
         (cat {input.sequences_ndjson:q} \
             | augur curate rename \
-                --field-map {params.field_map} \
+                --field-map {params.field_map:q} \
             | augur curate normalize-strings \
             | augur curate format-dates \
                 --date-fields {params.date_fields:q} \

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -8,7 +8,7 @@ REQUIRED INPUTS:
 OUTPUTS:
 
     metadata    = results/metadata.tsv
-    seuqences   = results/sequences.fasta
+    sequences   = results/sequences.fasta
 
 """
 

--- a/ingest/rules/curate.smk
+++ b/ingest/rules/curate.smk
@@ -34,7 +34,7 @@ rule concat_geolocation_rules:
         general_geolocation_rules="data/general-geolocation-rules.tsv",
         local_geolocation_rules=config["curate"]["local_geolocation_rules"],
     output:
-        all_geolocation_rules="data/all-geolocation-rules.tsv",
+        geolocation_rules="data/geolocation-rules.tsv",
     log:
         "logs/concat_geolocation_rules.txt",
     benchmark:
@@ -42,7 +42,7 @@ rule concat_geolocation_rules:
     shell:
         r"""
         cat {input.general_geolocation_rules:q} {input.local_geolocation_rules:q} \
-          > {output.all_geolocation_rules:q} 2> {log:q}
+          > {output.geolocation_rules:q} 2> {log:q}
         """
 
 
@@ -56,10 +56,10 @@ def format_field_map(field_map: dict[str, str]) -> str:
 rule curate:
     input:
         sequences_ndjson="data/ncbi.ndjson",
-        all_geolocation_rules="data/all-geolocation-rules.tsv",
+        geolocation_rules="data/geolocation-rules.tsv",
         annotations=config["curate"]["annotations"],
     output:
-        metadata=temp("data/all_metadata_intermediate.tsv"),
+        metadata=temp("data/metadata_intermediate.tsv"),
         sequences="results/sequences.fasta",
     log:
         "logs/curate.txt",
@@ -99,7 +99,7 @@ rule curate:
                 --default-value {params.authors_default_value:q} \
                 --abbr-authors-field {params.abbr_authors_field:q} \
             | augur curate apply-geolocation-rules \
-                --geolocation-rules {input.all_geolocation_rules:q} \
+                --geolocation-rules {input.geolocation_rules:q} \
             | augur curate apply-record-annotations \
                 --annotations {input.annotations:q} \
                 --id-field {params.annotations_id:q} \
@@ -113,9 +113,9 @@ rule curate:
 
 rule add_genbank_url:
     input:
-        metadata="data/all_metadata_intermediate.tsv",
+        metadata="data/metadata_intermediate.tsv",
     output:
-        metadata="data/all_metadata.tsv",
+        metadata="data/metadata.tsv",
     log:
         "logs/add_genbank_url.txt",
     benchmark:
@@ -131,7 +131,7 @@ rule add_genbank_url:
 
 rule subset_metadata:
     input:
-        metadata="data/all_metadata.tsv",
+        metadata="data/metadata.tsv",
     output:
         subset_metadata="results/metadata.tsv",
     params:

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -111,7 +111,7 @@ rule format_ncbi_datasets_ndjson:
             --fasta {input.ncbi_dataset_sequences:q} \
             --seq-id-column accession_version \
             --seq-field sequence \
-            --unmatched-reporting warn \
-            --duplicate-reporting warn \
+            --unmatched-reporting error_all \
+            --duplicate-reporting error_all \
           > {output.ndjson:q} 2> {log:q}
         """

--- a/ingest/rules/fetch_from_ncbi.smk
+++ b/ingest/rules/fetch_from_ncbi.smk
@@ -7,9 +7,30 @@ REQUIRED INPUTS:
 
 OUTPUTS:
 
-    ndjson = data/ncbi.ndjson
+    ndjson  = data/ncbi.ndjson
+    genbank = data/entrez.gb
 
 """
+
+
+rule fetch_ncbi_entrez_data:
+    params:
+        term=config["entrez_search_term"],
+    output:
+        genbank="data/entrez.gb",
+    # Allow retries in case of network errors
+    retries: 5
+    log:
+        "logs/fetch_ncbi_entrez_data.txt",
+    benchmark:
+        "benchmarks/fetch_ncbi_entrez_data.txt"
+    shell:
+        r"""
+        vendored/fetch-from-ncbi-entrez \
+            --term {params.term:q} \
+            --output {output.genbank:q}
+          2> {log:q}
+        """
 
 
 rule fetch_ncbi_dataset_package:

--- a/ingest/scripts/extract-genbank-annotations.py
+++ b/ingest/scripts/extract-genbank-annotations.py
@@ -1,0 +1,332 @@
+#! /usr/bin/env python
+"""
+Parses file with multiple GenBank records (provided via --genbank
+argument) to extract TSV-formatted accession, genotype, and best
+available date. Outputs TSV to STDOUT.
+
+Intended to be merged with other TSV-formatted data in subsequent
+`augur merge` step in workflow.
+"""
+
+import argparse
+import csv
+from datetime import date
+import re
+import sys
+
+from Bio import SeqIO
+
+# "official" WHO sample names for Rubella look like
+# 'RVi/Minsk.BLR/24.04/1[1E]' or 'RVs/Rouen.FRA/97[1E]'
+#
+# When present in GenBank records, they are found in the "source"
+# feature, in a `/strain` or `/isolate` annotation.
+#
+# If an "official" strain name is present, the first two letters will
+# always be "RV"; the third letter will be an 'i' or 's' (indicating
+# whether the RNA was derived from a viral isolate or a clinical
+# sample, correspondingly). The remainder of the genotype is
+# delineated by `/` characters.
+#
+# The next `/`-delineated section contains geographical information
+# for the sample: the city or state where the case occurred (only
+# ASCII characters (including spaces) allowed), followed by a ISO-3
+# country code; these two pieces of information are separated by a `.`.
+#
+# The next `/`-delineated section contains the date of onset of
+# disease (i.e., rash appearance, or sample collection date when rash
+# appearance date is unknown, or the date of sample receipt by the lab
+# if collection date is unknown), encoded as the "epiweek" followed by
+# a `.`, followed by a 2-digit year. Empirically, sometimes the
+# epiweek value is absent and only a year is present; additionally,
+# sometimes the year is given as a 4-digit year instead of 2.
+# Pragmatically, year values less than 30 will be assumed to be in
+# the 2000s; values greater than 30 will be assumed to be in the
+# 1900s.
+#
+# If there are multiple samples that are not distinguished by the
+# above rules, an additional monotonically-increasing integer is
+# appended after the trailing `/` character. Note that, when present,
+# this additional disambiguation character is NOT followed by an
+# additional `/` delimiter.
+#
+# The WHO genotype designation, if present, will be found after all
+# the above fields, in square brackets (e.g., `[2B]`)
+#
+# There may also be a trailing designation, usually in parentheses,
+# indicating the sample arises from an individual with congenital
+# rubella syndrome (CRS), newborns with a congenital rubella infection
+# (CRI), or a vaccine-derived strain (VAC). For cases marked with CRS
+# or CRI, the geographic localization is the place of birth and onset
+# date of disease is the date of birth.
+#
+# Samples may also have a "collection_date" annotation in the "source"
+# feature. If that is present and is not just a 4-digit year, this
+# script will output that for the date field; otherwise, if a genotype
+# with an epiweek and a year is present, the script will parse the
+# epiweek and year into a year-month date with an ambiguous day
+# component (e.g., 2020-01-XX for a epidate of `01.20`). If both
+# "collection_date" and the epi-date consist of only a year, the
+# script will output the "collection_date" year.
+#
+# In cases where the script can detect something that looks like a
+# genotype in the sample name, it will extract and report that. The
+# genotypes reported are limited to those defined by WHO (i.e., 1a,
+# 1B-1J, 2A-2C); they are further normalize to the set of provisional
+# and accepted genotypes given in the [2013 WHO Rubella nomenclature
+# publication][], so a 1A genotype will be normalized to 1a; a 1j
+# genotype will be normalized to 1J.
+#
+# [2013 WHO Rubella nomenclature publication]: https://www.who.int/publications/i/item/WER8832
+#
+# Occasionally, neither the strain and isolation annotations will
+# contain anything that can be parsed as an "offical" WHO genotype,
+# but there will be a `/note` annotation that looks like "genotype 1a"
+# or "Genotype: 2B". In that case the script will extract and return
+# the genotype, normalized as described above.
+
+
+def main():
+    args = _parse_args()
+
+    tsv_writer = csv.writer(sys.stdout, delimiter="\t")
+    tsv_writer.writerow(
+        [
+            "accession",
+            "date",
+            "genbank_genotype",
+        ]
+    )
+
+    for record in SeqIO.parse(args.genbank, "genbank"):
+        accession = record.annotations["accessions"][0]
+
+        for f in record.features:
+            if f.type == "source":
+                results = _parse_source_feature(f.qualifiers)
+
+                tsv_writer.writerow(
+                    [
+                        accession,
+                        _determine_best_date(results),
+                        results["genotype"],
+                    ]
+                )
+
+
+def _determine_best_date(results):
+    """
+    Extract the best date from what is available in `collection_date` and
+    the epi-date from the genotype, according to the following rules:
+
+    * Prefer the `collection_date`, if more specific than a simple bare
+      four-digit year
+    * Otherwise, use epi-date if both week and year parts are present
+    * Otherwise, if `collection_date` contains a four-digit year, use
+      that
+    * Otherwise, if the epi-date consists of only a year use that
+    * Finally, return the empty string
+
+    Notes/context on epiweek calculations:
+    https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1718643444417379
+    """
+    if results["collection_date"]:
+        # if we have a collection date and it's more than just a year, use that
+        if len(results["collection_date"]) > 4:
+            return results["collection_date"]
+
+        # otherwise if we have an epiweek and an epiyear, turn that
+        # into a date and use it
+        elif results["epiweek"] and results["epiyear"] and int(results["epiweek"]) > 0:
+            return _determine_epidate(int(results["epiweek"]), int(results["epiyear"]))
+
+        # otherwise, use the collection date
+        else:
+            return f"{results['collection_date']}-XX-XX"
+
+    # if there's no collection date but we have epiweek and epiyear,
+    # turn that into a date and use it
+    elif results["epiweek"] and results["epiyear"] and int(results["epiweek"]) > 0:
+        return _determine_epidate(int(results["epiweek"]), int(results["epiyear"]))
+
+    # otherwise, if there's no collection date and only an epiyear,
+    # use the epiyear
+    elif results["epiyear"]:
+        return f"{results['epiyear']}-XX-XX"
+
+    # …if we get here, we give up
+    else:
+        return ""
+
+
+def _determine_epidate(week, year):
+    """
+    Convert a WHO epi-week into an ISO week and return a month-year
+    date (e.g., 2025-01-XX) corresponding to the first day of that ISO
+    week.
+
+    WHO epi-week one begins with the first Monday of the year.
+
+    ISO week one begins with the first Monday of the first week of the
+    year that has at least 4 days (i.e., the first week of the year
+    that contains a Thursday).
+
+    This means that if the first day of the year is a Sunday, Monday,
+    Friday, or Saturday, the WHO epi-week and the ISO week numbers for
+    the year are the same.
+
+    If the first day of the year is a Tuesday, Wednesday, or Thursday,
+    the WHO epi-week number is consistently one lower than the ISO week.
+    """
+    jan_one_weekday = date(year, 1, 1).weekday()
+
+    if jan_one_weekday > 0 and jan_one_weekday < 4:
+        # if this is WHO epi-week one, it's actually the last ISO week
+        # of the previous year…
+        if week == 1:
+            year = year - 1
+            week = 52  # _might_ actually be 53, but be we only care about month in the end so going to 52 will DTRT
+        # …otherwise it's just one week less
+        else:
+            week = week - 1
+
+    # and then turn that into an ambigious-day datestring
+    return date.fromisocalendar(year, week, 1).strftime("%Y-%m-XX")
+
+
+def _normalize_year(year):
+    """
+    Heuristically convert a two-digit year into a four-digit one.
+    """
+    if int(year) <= 30:
+        return int(year) + 2000
+    elif int(year) > 30:
+        return int(year) + 1900
+    else:
+        raise ValueError(
+            f"YEAR {year!r} CANNOT BE NORMALIZED; THIS SHOULD BE IMPOSSIBLE"
+        )
+
+
+def _parse_args():
+    parser = argparse.ArgumentParser(
+        description="Extract genotype and epiweek date range from GenBank records."
+    )
+    parser.add_argument("--genbank", required=True, help="GenBank record file to parse")
+
+    return parser.parse_args()
+
+
+def _parse_date(date):
+    """
+    Heuristically turn a "epi-date" from a WHO genotype into a dict
+    with "epiweek" and "epiyear" keys, based on different formats
+    observed in the input dataset.
+    """
+    # case #1: actually follows WHO spec: two digit epiweek, followed
+    # by dot, followed by two digit year
+    match = re.search(r"^([0-9]{1,2})\.([0-9]{2})$", date)
+    if match:
+        return {
+            "epiweek": match.group(1),
+            "epiyear": str(_normalize_year(match.group(2))),
+        }
+
+    # case #2: kinda WHO spec but uses four digit year
+    match = re.search(r"^([0-9]{1,2})\.([0-9]{4})$", date)
+    if match:
+        return {"epiweek": match.group(1), "epiyear": match.group(2)}
+
+    # case #3: if there are only two digits, maybe with a leading `.`
+    # or maybe not, we assume it's a year
+    match = re.search(r"^.?([0-9]{2})$", date)
+    if match:
+        return {"epiweek": "", "epiyear": str(_normalize_year(match.group(1)))}
+
+    return {"epiweek": "", "epiyear": ""}
+
+
+def _parse_genotype(maybe_genotype):
+    """
+    Given a string that may contain a rubella genotype, extract the
+    genotype, normalize it to accepted WHO format, and return it (or
+    return the empty string if no genotype is found).
+    """
+    match = re.search(r"([12][aAbBcCdDeEfFgGhHiIjJ])", maybe_genotype)
+
+    if match:
+        genotype = match.group(1)
+        if re.search(r"1[aA]", genotype):
+            return genotype.lower()
+        else:
+            return genotype.upper()
+
+    return ""
+
+
+def _parse_source_feature(qualifiers):
+    """
+    Given a set of qualifiers from the "source" feature of a GenBank
+    record, attempt to extract and return the "collection_date",
+    "epiweek" and "epiyear" extracted from WHO strain name, and
+    "genotype" extracted also extracted from the WHO strain name.
+
+    Results are returned as a dict with keys named above; if values
+    cannot be extracted, the dict will have empty string values.
+    """
+    results = {
+        "collection_date": "",
+        "epiweek": "",
+        "epiyear": "",
+        "genotype": "",
+    }
+
+    # NOTE: SeqIO.parse turns all the source features into single element
+    # lists, which is why all the `.get()` calls below append a `[0]`
+
+    # extract the collection date, if it's present
+    results["collection_date"] = qualifiers.get("collection_date", [""])[0]
+
+    # Try to parse genotype and epidate, first from `strain`, and then
+    # from `isolate` only if `strain` is not present. This ordering is
+    # because, from empirical inspection, when both are present,
+    # strain contains the WHO strain designation and isolate does not
+    # — but when strain is missing, sometimes isolate has the WHO
+    # strain name.
+    isolate = qualifiers.get("isolate", [""])[0]
+    strain = qualifiers.get("strain", [""])[0]
+
+    if strain:
+        _parse_strain_name(strain, results)
+    elif isolate:
+        _parse_strain_name(isolate, results)
+
+    # if we didn't find a genotype in the strain or isolate, see if
+    # it's in the note
+    if not results["genotype"]:
+        note = qualifiers.get("note", [""])[0]
+        results["genotype"] = _parse_genotype(note)
+
+    return results
+
+
+def _parse_strain_name(name, results):
+    """
+    Given a putative WHO strain name and a results dict, attempt to
+    extract epiweek, epiyear, and genotype from the strain name, and
+    update the provided results dict accordingly.
+    """
+    if re.match(r"^RV[is]/", name):
+        parts = name.split("/", 3)[1:]
+
+        if len(parts) > 2:
+            location, date, rest = parts
+
+            parsed_date = _parse_date(date)
+            results["epiweek"] = parsed_date["epiweek"]
+            results["epiyear"] = parsed_date["epiyear"]
+
+            results["genotype"] = _parse_genotype(rest)
+
+
+main()

--- a/phylogenetic/defaults/config.yaml
+++ b/phylogenetic/defaults/config.yaml
@@ -5,17 +5,16 @@ strain_id_field: "accession"
 files:
   auspice_config: "defaults/auspice_config.json"
   description: "defaults/description.md"
+  exclude: "defaults/dropped_strains.txt"
   genome:
     auspice_title: "Real-time tracking of Rubella virus full genome evolution"
     clades: "defaults/clades_genome.tsv"
-    exclude: "defaults/dropped_strains_genome.txt"
     genemap: "defaults/genemap_genome.gff"
     include: "defaults/include_strains_genome.txt"
     reference: "defaults/reference_genome.fasta"
   E1:
     auspice_title: "Real-time tracking of Rubella virus E1 gene evolution"
     clades: "defaults/clades_E1.tsv"
-    exclude: "defaults/dropped_strains_E1.txt"
     genemap: "defaults/genemap_E1.gff"
     include: "defaults/include_strains_E1.txt"
     reference: "defaults/reference_E1.fasta"

--- a/phylogenetic/defaults/dropped_strains.txt
+++ b/phylogenetic/defaults/dropped_strains.txt
@@ -1,0 +1,4 @@
+JF727653  # off the clock
+JF727654  # off the clock
+FJ040181  # weirdly divergent
+EU016200  # weird epi-date in strain name

--- a/phylogenetic/defaults/dropped_strains_E1.txt
+++ b/phylogenetic/defaults/dropped_strains_E1.txt
@@ -1,3 +1,0 @@
-JF727653  #off the clock
-JF727654  #off the clock
-FJ040181  # weirdly divergent

--- a/phylogenetic/defaults/dropped_strains_genome.txt
+++ b/phylogenetic/defaults/dropped_strains_genome.txt
@@ -1,2 +1,0 @@
-JF727653  #off the clock
-JF727654  #off the clock

--- a/phylogenetic/rules/prepare_sequences.smk
+++ b/phylogenetic/rules/prepare_sequences.smk
@@ -34,7 +34,7 @@ rule decompress:
 
 rule filter_genome:
     input:
-        exclude=config["files"]["genome"]["exclude"],
+        exclude=config["files"]["exclude"],
         include=config["files"]["genome"]["include"],
         metadata="data/metadata.tsv",
         sequences="data/sequences.fasta",
@@ -111,7 +111,7 @@ rule filter_E1:
     input:
         sequences="results/E1/aligned.fasta",
         metadata="data/metadata.tsv",
-        exclude=config["files"]["E1"]["exclude"],
+        exclude=config["files"]["exclude"],
         include=config["files"]["E1"]["include"],
     output:
         sequences="results/E1/aligned_and_filtered.fasta",


### PR DESCRIPTION
## Description of proposed changes

Downloads Rubella sequences from GenBank and uses BioPython to extract best available date and genotype (if possible), then merges this in with existing NCBI Datasets metadata as part of ingest.

## Related issue(s)

Closes #24 
Closes #35 

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
