### PR TITLE
fix(nextclade): correct excessBandwidth typo

### DIFF
--- a/nextclade/defaults/nextclade-dataset/pathogen.json
+++ b/nextclade/defaults/nextclade-dataset/pathogen.json
@@ -17,7 +17,7 @@
   "alignmentParams": {
     "minSeedCover": 0.01,
     "terminalBandwidth": 100,
-    "excessBandwith": 18,
+    "excessBandwidth": 18,
     "minMatchLength": 20
   },
   "qc": {


### PR DESCRIPTION
Fix typo `excessBandwith` (missing "d") to `excessBandwidth` in `nextclade/defaults/nextclade-dataset/pathogen.json`.

The misspelled key is silently ignored by Nextclade, causing the default value (9) to be used instead of the intended value (18). This affects alignment quality for divergent E1 sequences by using a narrower band than intended.

- [x] Fix `excessBandwith` -> `excessBandwidth`

> :warning: The existing dataset in `nextclade_data` is already patched in nextstrain/nextclade_data#423, so no immediate resubmission is needed. But without this upstream fix, the typo will reappear on the next dataset submission from this workflow.

> :information_source: See [pathogen.json schema](https://github.com/nextstrain/nextclade/blob/master/packages/nextclade-schemas/input-pathogen-json.schema.json) (`AlignPairwiseParamsOptional` definition) for the full list of recognized alignment parameters.

1. Related to: nextstrain/nextclade_data#423